### PR TITLE
Remove storybook compilation

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -23,7 +23,6 @@ cd $build_dir
 
         echo "Found webpack, running webpack"
         $build_dir/node_modules/.bin/webpack --production
-        $build_dir/node_modules/.bin/build-storybook -c ./app/assets/javascripts/horse/react-ui/.storybook -o ./public/assets/build/design-system -s ./public/assets/build/design-system
         else
             echo "No webpack config found"
     fi


### PR DESCRIPTION
We don't need to compile storybook anymore since we moved it out of of the main app.